### PR TITLE
LED sync status was duplicated across devices

### DIFF
--- a/RGBSync+/UI/ConfigurationViewModel.cs
+++ b/RGBSync+/UI/ConfigurationViewModel.cs
@@ -396,7 +396,7 @@ namespace RGBSyncPlus.UI
 
                     dg.DeviceLeds = new ObservableCollection<DeviceLED>(RGBSurface.Instance.Leds
                         .Where(x => x.Device == d)
-                        .Select(y => new DeviceLED(y, SelectedSyncGroup.Leds.Any(x => x.LedId == y.Id))
+                        .Select(y => new DeviceLED(y, SelectedSyncGroup.Leds.Any(x => (x.LedId == y.Id) && (x.Device == y.Device.GetDeviceName())))
                         {
                             ParentalRollUp = dg.RollUpCheckBoxes
                         }).ToList());


### PR DESCRIPTION
Fixed UI bug where LEDs with identical IDs (e.g. "LEDStrip1") would become syncd even if they were located on different devices.  Now, we don't mark the LED as syncd unless both the ID AND the device name match.