### PR TITLE
Compensate for bad system configuration

### DIFF
--- a/RGBSync+/ApplicationManager.cs
+++ b/RGBSync+/ApplicationManager.cs
@@ -296,6 +296,8 @@ namespace RGBSyncPlus
 
             try
             {
+                // Set system security protocol to the best of our capabilities
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
                 using (WebClient w = new WebClient())
                 {
                     Logger.Info("Checking for update...");


### PR DESCRIPTION
Some machines which are not configured to use SSL 3.0 may fail connecting to the update server.
From that point, the updater crashes because it cannot connect.